### PR TITLE
Breaking Change: `forceAppendPeriod`オプションの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,21 +34,55 @@ Via CLI
 textlint --rule ja-no-mixed-period README.md
 ```
 
+## Examples
+
+**OK**:
+
+```
+これは問題ないです。
+末尾に感嘆符はある!
+「これはセリフ」
+english only
+- 箇条書きは無視される
+```
+
+**NG**:
+
+```
+これは句点がありません
+末尾にスペースがある。           
+絵文字が末尾にある。😆
+```
+
 ## Options
 
-- `periodMark`(string):
+- `periodMark`: `string`:
     - 文末に使用する句点文字
     - デフォルト: "。"
-
+- `allowPeriodMarks`: `string[]`
+    - 句点文字として許可する文字列の配列
+    - 例外として許可したい文字列を設定する
+    - `periodMark`に指定したものは自動的に許可リストに加わる
+    - デフォルトは空 `[]`
 - `allowEmojiAtEnd`(bool):
     - 絵文字を末尾に置くことを許可するかどうか
+    - デフォルト: false
+- `forceAppendPeriod`: `boolean`
+    - 句点で終わって無い場合に`periodMark`を--fix時に追加するかどうか
     - デフォルト: false
 
 ```json
 {
     "rules": {
         "ja-no-mixed-period": {
-            "periodMark": "。"
+             // 優先する句点文字
+             "periodMark": "。",
+             // 句点文字として許可する文字列の配列
+             "allowPeriodMarks": [],
+             // 末尾に絵文字を置くことを許可するか
+             "allowEmojiAtEnd": false,
+             // 句点で終わって無い場合に`periodMark`を--fix時に追加するかどうか
+             "forceAppendPeriod": false
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "textlint-tester": "^2.0.0"
   },
   "dependencies": {
-    "emoji-regex": "^6.1.0",
+    "check-ends-with-period": "^1.0.1",
     "textlint-rule-helper": "^2.0.0"
   }
 }

--- a/test/textlint-rule-ja-no-mixed-period-test.js
+++ b/test/textlint-rule-ja-no-mixed-period-test.js
@@ -8,6 +8,7 @@ tester.run("textlint-rule-ja-no-mixed-period", rule, {
         "1行目。  \nHard Breakを入れるパターン。",
         "1行目  空白はあるけど末尾に句点はある。",
         // 例外: 感嘆符などが末尾にある場合は問題なし
+        "「これはセリフ」",
         "末尾に句点はある!",
         "english only",
         // 例外のNode type
@@ -18,17 +19,26 @@ tester.run("textlint-rule-ja-no-mixed-period", rule, {
         `__強調表示も同じく__`,
         `> 引用も無視される`,
         {
-          text: "絵文字が末尾にある。😆",
-          options: {
-            allowEmojiAtEnd: true
-          },
+            text: "絵文字が末尾にある。😆",
+            options: {
+                allowEmojiAtEnd: true
+            },
         },
+        {
+            text: "これはOK",
+            options: {
+                allowPeriodMarks: ["OK"]
+            },
+        }
     ],
     invalid: [
         // single match
         {
             text: "これは句点がありません",
             output: "これは句点がありません。",
+            options: {
+                forceAppendPeriod: true
+            },
             errors: [
                 {
                     message: `文末が"。"で終わっていません。`,
@@ -41,6 +51,9 @@ tester.run("textlint-rule-ja-no-mixed-period", rule, {
         {
             text: "これは句点がありません\n\nこれは句点がありません",
             output: "これは句点がありません。\n\nこれは句点がありません。",
+            options: {
+                forceAppendPeriod: true
+            },
             errors: [
                 {
                     message: `文末が"。"で終わっていません。`,
@@ -56,11 +69,23 @@ tester.run("textlint-rule-ja-no-mixed-period", rule, {
         },
         {
             text: "末尾にスペースがある。 ",
+            output: "末尾にスペースがある。",
             errors: [
                 {
                     message: `文末が"。"で終わっていません。末尾に不要なスペースがあります。`,
                     line: 1,
-                    column: 12
+                    column: 12 // space
+                }
+            ]
+        },
+        {
+            text: "末尾にスペースがある。           ",
+            output: "末尾にスペースがある。",
+            errors: [
+                {
+                    message: `文末が"。"で終わっていません。末尾に不要なスペースがあります。`,
+                    line: 1,
+                    column: 12 // space の開始位置
                 }
             ]
         },
@@ -68,6 +93,9 @@ tester.run("textlint-rule-ja-no-mixed-period", rule, {
         {
             text: "これは句点がありません、これは句点がありません",
             output: "これは句点がありません、これは句点がありません。",
+            options: {
+                forceAppendPeriod: true
+            },
             errors: [
                 {
                     message: `文末が"。"で終わっていません。`,
@@ -81,7 +109,8 @@ tester.run("textlint-rule-ja-no-mixed-period", rule, {
             text: "これはダメ",
             output: "これはダメ.",
             options: {
-                periodMark: "."
+                periodMark: ".",
+                forceAppendPeriod: true
             },
             errors: [
                 {


### PR DESCRIPTION
## Breaking Changes

- `forceAppendPeriod`: `true` の場合は自動的に `--fix`で句点を追加するように変更(今までのデフォルトは自動追加のみだった)
  - デフォルトはOFFであるためBREAKING CHANGE
  - 今までのように末尾に句点がないときに句点を問答無用で追加したい場合は `forceAppendPeriod`: `true` としてください。

## Features
- `allowPeriodMarks`: `[]`を追加
  - 例外となる句点を登録できるオプション

## Internal
- 句点判定の処理をライブラリ化
- [azu/check-ends-with-period: Check the text is ends with period mark.](https://github.com/azu/check-ends-with-period "azu/check-ends-with-period: Check the text is ends with period mark.")